### PR TITLE
Feature: alter project version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Added
+- New configuration option: `alterProjectVersion` which when set to false prevents the plugin to modify the project version
 
 ## [0.0.2] - 2025-04-19
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     kotlin("jvm") version "2.1.20"
     `kotlin-dsl`
-    id("dev.zucca-ops.gradle-publisher") version "0.0.1-develop-SNAPSHOT"
+    id("dev.zucca-ops.gradle-publisher") version "0.0.2"
     id("java-gradle-plugin")
     signing
     id("com.diffplug.spotless") version "7.0.3"
@@ -13,9 +13,6 @@ version = "0.0.2"
 
 repositories {
     mavenCentral()
-    maven {
-        url = uri("https://zucca.jfrog.io/artifactory/publisher-libs-snapshot")
-    }
 }
 
 dependencies {

--- a/src/main/kotlin/configuration/Defaults.kt
+++ b/src/main/kotlin/configuration/Defaults.kt
@@ -36,5 +36,6 @@ object Defaults {
     const val USER_PROPERTY = "mavenUsername"
     const val PASS_PROPERTY = "mavenPassword"
     const val GIT_FOLDER = "."
+    const val ALTER_PROJECT_VERSION = true
     val RELEASE_BRANCH_REGEXES: List<String> = emptyList()
 }

--- a/src/main/kotlin/configuration/PluginConfiguration.kt
+++ b/src/main/kotlin/configuration/PluginConfiguration.kt
@@ -80,7 +80,10 @@ open class PluginConfiguration
         /** List of regex patterns to identify release branches */
         var releaseBranchPatterns: List<String> = Defaults.RELEASE_BRANCH_REGEXES
 
-        override fun toString(): String =
+        /** If true, the plugin modifies the project version on non-release branches */
+        var alterProjectVersion: Boolean = Defaults.ALTER_PROJECT_VERSION
+
+    override fun toString(): String =
             buildString {
                 appendLine("PluginConfiguration(")
                 appendLine("  dev = $dev")
@@ -89,6 +92,7 @@ open class PluginConfiguration
                 appendLine("  passwordProperty = $passwordProperty")
                 appendLine("  releaseBranchPatterns = $releaseBranchPatterns")
                 appendLine("  gitFolder = $gitFolder")
+                appendLine("  alterProjectVersion = $alterProjectVersion")
                 append(")")
             }
     }

--- a/src/main/kotlin/configuration/PluginConfiguration.kt
+++ b/src/main/kotlin/configuration/PluginConfiguration.kt
@@ -83,7 +83,7 @@ open class PluginConfiguration
         /** If true, the plugin modifies the project version on non-release branches */
         var alterProjectVersion: Boolean = Defaults.ALTER_PROJECT_VERSION
 
-    override fun toString(): String =
+        override fun toString(): String =
             buildString {
                 appendLine("PluginConfiguration(")
                 appendLine("  dev = $dev")

--- a/src/main/kotlin/helpers/VersionResolver.kt
+++ b/src/main/kotlin/helpers/VersionResolver.kt
@@ -62,11 +62,17 @@ class VersionResolver(
 
     /**
      * Returns the project version to use for publication.
-     * If version modification is enabled, returns the computed version (e.g., with branch suffix).
+     * If version modification is enabled, returns the computed version (e.g., with a branch suffix).
      * Otherwise, returns the original project version as defined in build.gradle.
      */
     fun getVersionForProject(): String {
-        return if (configuration.alterProjectVersion) getVersion() else getProjectVersion()
+        if (configuration.alterProjectVersion) {
+            project.logger.lifecycle("Setting project version to computed value")
+            return getVersion()
+        }
+
+        project.logger.info("alterProjectVersion is false, skipping project version modification")
+        return getProjectVersion()
     }
 
     /** Escapes slashes in the branch name for safe use in versions. */

--- a/src/main/kotlin/helpers/VersionResolver.kt
+++ b/src/main/kotlin/helpers/VersionResolver.kt
@@ -49,7 +49,7 @@ class VersionResolver(
         if (finalVersion == null) {
             val baseVersion = getProjectVersion()
             finalVersion =
-                if (isRelease()) {
+                if (isRelease() || !configuration.alterProjectVersion) {
                     baseVersion
                 } else {
                     "$baseVersion-${getEscapedBranchName()}-SNAPSHOT"

--- a/src/main/kotlin/helpers/VersionResolver.kt
+++ b/src/main/kotlin/helpers/VersionResolver.kt
@@ -49,7 +49,7 @@ class VersionResolver(
         if (finalVersion == null) {
             val baseVersion = getProjectVersion()
             finalVersion =
-                if (isRelease() || !configuration.alterProjectVersion) {
+                if (isRelease()) {
                     baseVersion
                 } else {
                     "$baseVersion-${getEscapedBranchName()}-SNAPSHOT"
@@ -58,6 +58,15 @@ class VersionResolver(
         }
 
         return finalVersion!!
+    }
+
+    /**
+     * Returns the project version to use for publication.
+     * If version modification is enabled, returns the computed version (e.g., with branch suffix).
+     * Otherwise, returns the original project version as defined in build.gradle.
+     */
+    fun getVersionForProject(): String {
+        return if (configuration.alterProjectVersion) getVersion() else getProjectVersion()
     }
 
     /** Escapes slashes in the branch name for safe use in versions. */

--- a/src/main/kotlin/repositories/BaseRepositoryPublisher.kt
+++ b/src/main/kotlin/repositories/BaseRepositoryPublisher.kt
@@ -63,7 +63,7 @@ abstract class BaseRepositoryPublisher(
             project.logger.info("Registering repositories")
             registerRepository(this.repositories)
 
-            project.version = versionResolver.getVersion()
+            project.version = versionResolver.getVersionForProject()
 
             if (!isPublishable()) {
                 project.logger.info("Version not publishable, disabling the following tasks:")

--- a/src/main/kotlin/repositories/BaseRepositoryPublisher.kt
+++ b/src/main/kotlin/repositories/BaseRepositoryPublisher.kt
@@ -64,6 +64,7 @@ abstract class BaseRepositoryPublisher(
             registerRepository(this.repositories)
 
             project.version = versionResolver.getVersion()
+
             if (!isPublishable()) {
                 project.logger.info("Version not publishable, disabling the following tasks:")
                 project.tasks.withType(PublishToMavenRepository::class.java).configureEach {

--- a/src/main/kotlin/repositories/central/MavenCentralRepositoryPublisher.kt
+++ b/src/main/kotlin/repositories/central/MavenCentralRepositoryPublisher.kt
@@ -51,6 +51,12 @@ class MavenCentralRepositoryPublisher(
      * Also finalizes the `publish` task with `publishToMavenCentralPortal`.
      */
     override fun configurePublishingRepository() {
+        super.configurePublishingRepository()
+
+        if (!isPublishable()) {
+            return
+        }
+
         val username = repositoryAuthenticator.getProdUsername()
         val password = repositoryAuthenticator.getProdPassword()
 
@@ -66,9 +72,8 @@ class MavenCentralRepositoryPublisher(
 
         if (!versionResolver.isRelease()) {
             project.logger.error("Maven Central is not allowing snapshots yet, please configure a different target for dev environments")
+            return
         }
-
-        super.configurePublishingRepository()
 
         project.logger.lifecycle("Applying tech.yanand.maven-central-publish plugin")
         project.pluginManager.apply("tech.yanand.maven-central-publish")


### PR DESCRIPTION
Adds the new configuration option: alterProjectVersion (#15) which can be set to `false ` preventing the project version change feature happening on dev branches