### PR TITLE
Only configuring repositories on publish command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Plugin logic now only executes when the `publish` task is explicitly requested (`./gradlew publish`)
+- This avoids side effects during unrelated tasks like `build` or `test`
+
+### Highlights
+- Finalizes stable publishing flow
+
 ## [0.1.1] - 2025-04-20
 ### Added
 - Configuration validation to prevent the plugin from running in an invalid or incomplete state

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
     jvmToolchain(17)
 }
 
+@Suppress("UnstableApiUsage")
 gradlePlugin {
     website = "https://github.com/zucca-devops-tooling/gradle-publisher"
     vcsUrl = "https://github.com/zucca-devops-tooling/gradle-publisher.git"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     kotlin("jvm") version "2.1.20"
     `kotlin-dsl`
-    id("dev.zucca-ops.gradle-publisher") version "0.1.1"
+    id("dev.zucca-ops.gradle-publisher") version "0.1.1-PR-27-SNAPSHOT"
     id("java-gradle-plugin")
     signing
     id("com.diffplug.spotless") version "7.0.3"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     kotlin("jvm") version "2.1.20"
     `kotlin-dsl`
-    id("dev.zucca-ops.gradle-publisher") version "0.1.0"
+    id("dev.zucca-ops.gradle-publisher") version "0.1.1"
     id("java-gradle-plugin")
     signing
     id("com.diffplug.spotless") version "7.0.3"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     kotlin("jvm") version "2.1.20"
     `kotlin-dsl`
-    id("dev.zucca-ops.gradle-publisher") version "0.1.1-PR-27-SNAPSHOT"
+    id("dev.zucca-ops.gradle-publisher") version "0.1.1"
     id("java-gradle-plugin")
     signing
     id("com.diffplug.spotless") version "7.0.3"

--- a/src/main/kotlin/GradlePublisherPlugin.kt
+++ b/src/main/kotlin/GradlePublisherPlugin.kt
@@ -18,8 +18,10 @@ package dev.zuccaops
 import dev.zuccaops.configuration.PluginConfiguration
 import dev.zuccaops.repositories.RepositoryPublisher
 import dev.zuccaops.repositories.RepositoryPublisherFactory
+import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.execution.TaskExecutionGraph
 
 /**
  * The main entry point for the Gradle Publisher plugin.
@@ -41,15 +43,19 @@ class GradlePublisherPlugin : Plugin<Project> {
         target.plugins.apply("maven-publish")
 
         target.tasks.named("publish") {
-            logger.debug("Ensuring 'publish' depends on 'build'")
-            dependsOn(target.tasks.named("build"))
+            logger.debug("Ensuring 'publish' depends on 'assemble'")
+            dependsOn(target.tasks.named("assemble"))
         }
 
         target.afterEvaluate {
-            logger.info("Plugin configuration: $configuration")
-            val repositoryPublisher: RepositoryPublisher = RepositoryPublisherFactory.get(this, configuration)
+            val requestedTasks = gradle.startParameter.taskNames
 
-            repositoryPublisher.configurePublishingRepository()
+            if (requestedTasks.any { it.contains("publish", ignoreCase = true) }) {
+                logger.info("Plugin configuration: $configuration")
+                val repositoryPublisher: RepositoryPublisher = RepositoryPublisherFactory.get(this, configuration)
+
+                repositoryPublisher.configurePublishingRepository()
+            }
         }
     }
 }

--- a/src/main/kotlin/GradlePublisherPlugin.kt
+++ b/src/main/kotlin/GradlePublisherPlugin.kt
@@ -18,10 +18,8 @@ package dev.zuccaops
 import dev.zuccaops.configuration.PluginConfiguration
 import dev.zuccaops.repositories.RepositoryPublisher
 import dev.zuccaops.repositories.RepositoryPublisherFactory
-import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.execution.TaskExecutionGraph
 
 /**
  * The main entry point for the Gradle Publisher plugin.


### PR DESCRIPTION
The plugin should not execute in tasks other than `publish`  (#21)
This will prevent unnecessary early stage failures, overhead and configurations like setting credentials