### PR TITLE
Check that `publish` is explicit in requestedTasks

### DIFF
--- a/src/main/kotlin/GradlePublisherPlugin.kt
+++ b/src/main/kotlin/GradlePublisherPlugin.kt
@@ -52,7 +52,7 @@ class GradlePublisherPlugin : Plugin<Project> {
             val repositoryPublisher: RepositoryPublisher = RepositoryPublisherFactory.get(this, configuration)
             repositoryPublisher.setProjectVersion()
 
-            if (requestedTasks.any { it.contains("publish", ignoreCase = true) }) {
+            if ("publish" in requestedTasks) {
                 repositoryPublisher.configurePublishingRepository()
             }
         }


### PR DESCRIPTION
Minor fix, the plugin is still processing in unrelated tasks other than publish (#35)
A more strict evaluation of requestedTasks should be performed