### PR TITLE
Replace Yanand Central Portal runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added an internal Java 17 Central Portal client that uploads Maven deployment bundles with Bearer authentication and polls deployment status.
+- Added focused unit, functional, and offline packaged-plugin integration coverage for Central Portal publishing.
+
+### Changed
+- Maven Central publishing now creates `build/repos/bundles.zip` with a Gradle `Zip` task and uploads it through the existing `publishToMavenCentralPortal` task using `USER_MANAGED` publishing.
+
+### Removed
+- Removed the Yanand Maven Central publishing runtime dependency, dynamic plugin application, reflective extension configuration, and Layer 3 dependency staging.
+
 ## [1.1.1] - 2026-03-27
 ### Fixed
 - Branch detection now prefers CI-provided branch metadata and ignores `grafted`/symbolic remote decorations that can appear in shallow GitHub Actions checkouts.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ publisher {
 
 This routes `publish` to `publishToMavenCentralPortal`.
 
+The plugin publishes Maven-layout artifacts into `build/repos/bundles`, creates
+`build/repos/bundles.zip`, and uploads that bundle to the Central Portal Publisher
+API with `USER_MANAGED` publishing. The task waits for validation and then leaves
+the deployment ready for manual publishing in the Central Portal.
+The configured portal username and password are Base64-encoded as
+`username:password` and sent as a Bearer token.
+
 ### Nexus / OSSRH
 
 ```kotlin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,6 @@ version = "1.1.1"
 val integrationTestCandidateVersion = "0.0.0-integration-test"
 val integrationTestRepositoryDirectory = layout.buildDirectory.dir("integration-test-repository")
 val integrationTestConsumerDirectory = layout.buildDirectory.dir("integration-test-consumers")
-val mavenCentralPublishPluginVersion = "1.2.0"
 
 repositories {
     mavenCentral()
@@ -27,10 +26,6 @@ dependencies {
     testImplementation("io.mockk:mockk-agent-jvm:1.14.6")
     implementation(gradleApi())
     implementation(localGroovy())
-    implementation(
-        "tech.yanand.maven-central-publish:" +
-            "tech.yanand.maven-central-publish.gradle.plugin:$mavenCentralPublishPluginVersion",
-    )
 }
 
 val functionalTestSourceSet = sourceSets.create("functionalTest")
@@ -45,38 +40,9 @@ configurations[integrationTestSourceSet.implementationConfigurationName]
 configurations[integrationTestSourceSet.runtimeOnlyConfigurationName]
     .extendsFrom(configurations.testRuntimeOnly.get())
 
-val integrationTestRuntimeMarkerPom by configurations.creating {
-    isCanBeConsumed = false
-    isCanBeResolved = true
-    isTransitive = false
-}
-val integrationTestRuntimeImplementationPom by configurations.creating {
-    isCanBeConsumed = false
-    isCanBeResolved = true
-    isTransitive = false
-}
-val integrationTestRuntimeImplementationJar by configurations.creating {
-    isCanBeConsumed = false
-    isCanBeResolved = true
-    isTransitive = false
-}
-
 dependencies {
     add(functionalTestSourceSet.implementationConfigurationName, gradleTestKit())
     add(integrationTestSourceSet.implementationConfigurationName, gradleTestKit())
-    add(
-        integrationTestRuntimeMarkerPom.name,
-        "tech.yanand.maven-central-publish:" +
-            "tech.yanand.maven-central-publish.gradle.plugin:$mavenCentralPublishPluginVersion@pom",
-    )
-    add(
-        integrationTestRuntimeImplementationPom.name,
-        "tech.yanand.gradle:maven-central-publish:$mavenCentralPublishPluginVersion@pom",
-    )
-    add(
-        integrationTestRuntimeImplementationJar.name,
-        "tech.yanand.gradle:maven-central-publish:$mavenCentralPublishPluginVersion",
-    )
 }
 
 tasks.test {
@@ -107,59 +73,6 @@ val cleanIntegrationTestConsumers =
         delete(integrationTestConsumerDirectory)
     }
 
-val runtimeMarkerPom =
-    integrationTestRepositoryDirectory.map {
-        it.file(
-            "tech/yanand/maven-central-publish/" +
-                "tech.yanand.maven-central-publish.gradle.plugin/" +
-                "$mavenCentralPublishPluginVersion/" +
-                "tech.yanand.maven-central-publish.gradle.plugin-$mavenCentralPublishPluginVersion.pom",
-        ).asFile
-    }
-val runtimeImplementationPom =
-    integrationTestRepositoryDirectory.map {
-        it.file(
-            "tech/yanand/gradle/maven-central-publish/" +
-                "$mavenCentralPublishPluginVersion/" +
-                "maven-central-publish-$mavenCentralPublishPluginVersion.pom",
-        ).asFile
-    }
-val runtimeImplementationJar =
-    integrationTestRepositoryDirectory.map {
-        it.file(
-            "tech/yanand/gradle/maven-central-publish/" +
-                "$mavenCentralPublishPluginVersion/" +
-                "maven-central-publish-$mavenCentralPublishPluginVersion.jar",
-        ).asFile
-    }
-
-val stageIntegrationTestRuntimeDependencies =
-    tasks.register("stageIntegrationTestRuntimeDependencies") {
-        description = "Stages packaged plugin runtime dependencies in the integration-test repository."
-        group = LifecycleBasePlugin.BUILD_GROUP
-        dependsOn(cleanIntegrationTestRepository)
-        inputs.files(
-            integrationTestRuntimeMarkerPom,
-            integrationTestRuntimeImplementationPom,
-            integrationTestRuntimeImplementationJar,
-        )
-        outputs.files(runtimeMarkerPom, runtimeImplementationPom, runtimeImplementationJar)
-
-        doLast {
-            fun copySingleFile(
-                source: Configuration,
-                destination: File,
-            ) {
-                destination.parentFile.mkdirs()
-                source.singleFile.copyTo(destination, overwrite = true)
-            }
-
-            copySingleFile(integrationTestRuntimeMarkerPom, runtimeMarkerPom.get())
-            copySingleFile(integrationTestRuntimeImplementationPom, runtimeImplementationPom.get())
-            copySingleFile(integrationTestRuntimeImplementationJar, runtimeImplementationJar.get())
-        }
-    }
-
 val candidatePublicationTasks =
     listOf(
         "publishIntegrationTestPluginMavenPublicationToIntegrationTestRepository",
@@ -174,7 +87,6 @@ val prepareIntegrationTestRepository =
     tasks.register("prepareIntegrationTestRepository") {
         description = "Publishes the packaged candidate plugin into an isolated Maven repository."
         group = LifecycleBasePlugin.BUILD_GROUP
-        dependsOn(stageIntegrationTestRuntimeDependencies)
         dependsOn(candidatePublicationTasks)
         outputs.dir(integrationTestRepositoryDirectory)
     }

--- a/src/functionalTest/kotlin/functional/CentralPortalPublishingFunctionalTest.kt
+++ b/src/functionalTest/kotlin/functional/CentralPortalPublishingFunctionalTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 GuidoZuccarelli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package functional
+
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.nio.file.Path
+import java.util.Base64
+import java.util.zip.ZipInputStream
+
+class CentralPortalPublishingFunctionalTest {
+    lateinit var temporaryDirectory: Path
+
+    @BeforeEach
+    fun createTemporaryDirectory() {
+        temporaryDirectory = newFunctionalTestDirectory("central-portal")
+    }
+
+    @Test
+    fun `publishes a Maven bundle to the Central Portal with a local fake server`() {
+        FakeCentralPortal().use { portal ->
+            val project =
+                FunctionalTestProject(
+                    temporaryDirectory,
+                    branch = "release/1.2.3",
+                    buildScript =
+                        publisherBuildScript(
+                            devConfiguration =
+                                """
+                                target = "local"
+                                sign = false
+                                """,
+                            prodConfiguration =
+                                """
+                                target = "mavenCentral"
+                                usernameProperty = "portalUser"
+                                passwordProperty = "portalPassword"
+                                sign = false
+                                """,
+                        ),
+                )
+
+            val result =
+                project.build(
+                    "publish",
+                    arguments =
+                        listOf(
+                            "-PportalUser=publisher-user",
+                            "-PportalPassword=publisher-password",
+                            "-PmavenCentralRepositoryBaseUrl=${portal.repositoryUri}",
+                            "-PmavenCentralPortalBaseUrl=${portal.uri}",
+                            "-PmavenCentralPortalPollIntervalMillis=1",
+                        ),
+                )
+
+            assertEquals(TaskOutcome.SUCCESS, result.task(":publishMavenPublicationToLocalRepository")?.outcome)
+            assertEquals(TaskOutcome.SUCCESS, result.task(":zipBundleForUpload")?.outcome)
+            assertEquals(TaskOutcome.SUCCESS, result.task(":publishToMavenCentralPortal")?.outcome)
+            assertFalse(result.output.contains("https://central.sonatype.com/api/"))
+
+            val expectedAuthorization =
+                "Bearer " +
+                    Base64
+                        .getEncoder()
+                        .encodeToString("publisher-user:publisher-password".toByteArray())
+            val uploadRequest = portal.requests.single { it.path == "/api/v1/publisher/upload" }
+            assertEquals("POST", uploadRequest.method)
+            assertEquals("publishingType=USER_MANAGED", uploadRequest.query)
+            assertEquals(expectedAuthorization, uploadRequest.authorization)
+
+            val bundle = requireNotNull(portal.uploadedBundle)
+            val entries = zipEntries(bundle)
+            val artifactPath = "com/example/test-library/1.2.3/test-library-1.2.3"
+            assertTrue(entries.contains("$artifactPath.jar"))
+            assertTrue(entries.contains("$artifactPath.pom"))
+
+            val statusRequests = portal.requests.filter { it.path == "/api/v1/publisher/status" }
+            assertEquals(3, statusRequests.size)
+            assertTrue(statusRequests.all { it.method == "POST" })
+            assertTrue(statusRequests.all { it.query == "id=deployment-123" })
+            assertTrue(
+                portal.requests.any {
+                    it.method == "GET" &&
+                        it.path == "/repository/com/example/test-library/1.2.3"
+                },
+            )
+        }
+    }
+
+    private fun zipEntries(bundle: ByteArray): Set<String> =
+        ZipInputStream(ByteArrayInputStream(bundle)).use { zip ->
+            buildSet {
+                var entry = zip.nextEntry
+                while (entry != null) {
+                    add(entry.name)
+                    entry = zip.nextEntry
+                }
+            }
+        }
+}

--- a/src/functionalTest/kotlin/functional/FakeCentralPortal.kt
+++ b/src/functionalTest/kotlin/functional/FakeCentralPortal.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 GuidoZuccarelli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package functional
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import java.net.URI
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+
+internal class FakeCentralPortal : AutoCloseable {
+    data class Request(
+        val method: String,
+        val path: String,
+        val query: String?,
+        val authorization: String?,
+    )
+
+    private val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    private val recordedRequests = CopyOnWriteArrayList<Request>()
+    private val statusIndex = AtomicInteger()
+    private val statuses = listOf("PENDING", "VALIDATING", "VALIDATED")
+
+    var uploadedBundle: ByteArray? = null
+        private set
+
+    val uri: URI
+        get() = URI("http://127.0.0.1:${server.address.port}")
+
+    val repositoryUri: URI
+        get() = uri.resolve("/repository")
+
+    val requests: List<Request>
+        get() = recordedRequests.toList()
+
+    init {
+        server.createContext("/repository") { exchange ->
+            record(exchange)
+            exchange.sendResponseHeaders(404, -1)
+            exchange.close()
+        }
+        server.createContext("/api/v1/publisher/upload") { exchange ->
+            record(exchange)
+            uploadedBundle = extractBundle(exchange)
+            respond(exchange, 201, "deployment-123")
+        }
+        server.createContext("/api/v1/publisher/status") { exchange ->
+            record(exchange)
+            val index = statusIndex.getAndIncrement().coerceAtMost(statuses.lastIndex)
+            respond(exchange, 200, """{"deploymentState":"${statuses[index]}"}""")
+        }
+        server.start()
+    }
+
+    override fun close() {
+        server.stop(0)
+    }
+
+    private fun record(exchange: HttpExchange) {
+        recordedRequests +=
+            Request(
+                method = exchange.requestMethod,
+                path = exchange.requestURI.path,
+                query = exchange.requestURI.rawQuery,
+                authorization = exchange.requestHeaders.getFirst("Authorization"),
+            )
+    }
+
+    private fun extractBundle(exchange: HttpExchange): ByteArray {
+        val contentType = exchange.requestHeaders.getFirst("Content-Type")
+        val boundary = contentType.substringAfter("boundary=")
+        val body = exchange.requestBody.use { it.readBytes() }
+        val contentStart = body.indexOf("\r\n\r\n".toByteArray(UTF_8)) + 4
+        val contentEnd = body.indexOf("\r\n--$boundary--".toByteArray(UTF_8), contentStart)
+
+        check(contentStart >= 4 && contentEnd >= contentStart) {
+            "Invalid multipart request body"
+        }
+        return body.copyOfRange(contentStart, contentEnd)
+    }
+
+    private fun respond(
+        exchange: HttpExchange,
+        status: Int,
+        response: String,
+    ) {
+        val body = response.toByteArray(UTF_8)
+        exchange.sendResponseHeaders(status, body.size.toLong())
+        exchange.responseBody.use { it.write(body) }
+        exchange.close()
+    }
+}
+
+private fun ByteArray.indexOf(
+    target: ByteArray,
+    startIndex: Int = 0,
+): Int {
+    if (target.isEmpty()) {
+        return startIndex.coerceAtMost(size)
+    }
+
+    for (index in startIndex..size - target.size) {
+        if (target.indices.all { offset -> this[index + offset] == target[offset] }) {
+            return index
+        }
+    }
+
+    return -1
+}

--- a/src/integrationTest/kotlin/integration/PackagedPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/integration/PackagedPluginIntegrationTest.kt
@@ -19,6 +19,7 @@ import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -51,7 +52,7 @@ class PackagedPluginIntegrationTest {
     }
 
     @Test
-    fun `candidate repository contains a resolvable plugin marker implementation and runtime metadata`() {
+    fun `candidate repository contains a self-contained resolvable plugin`() {
         val markerPom = markerArtifactDirectory().resolve("$PLUGIN_ID.gradle.plugin-$candidateVersion.pom")
         val implementationPom = implementationArtifactDirectory().resolve("$IMPLEMENTATION_ARTIFACT-$candidateVersion.pom")
         val implementationModule = implementationArtifactDirectory().resolve("$IMPLEMENTATION_ARTIFACT-$candidateVersion.module")
@@ -66,15 +67,15 @@ class PackagedPluginIntegrationTest {
         assertTrue(implementationPom.exists(), "The implementation POM must be published")
         assertTrue(implementationModule.exists(), "Gradle module metadata must be published")
         assertTrue(implementationJar.exists(), "The implementation JAR must be published")
-        assertTrue(
-            dependenciesIn(implementationPom).contains(
-                Coordinate(
-                    "tech.yanand.maven-central-publish",
-                    "tech.yanand.maven-central-publish.gradle.plugin",
-                    "1.2.0",
-                ),
-            ),
-            "The packaged implementation metadata must retain its runtime dependency",
+        assertFalse(
+            dependenciesIn(implementationPom).any { dependency ->
+                dependency.group.startsWith("tech.yanand")
+            },
+            "The packaged implementation POM must not depend on Yanand",
+        )
+        assertFalse(
+            implementationModule.readText().contains("tech.yanand"),
+            "The packaged Gradle module metadata must not depend on Yanand",
         )
 
         ZipFile(implementationJar.toFile()).use { jar ->
@@ -85,20 +86,9 @@ class PackagedPluginIntegrationTest {
             assertEquals("dev.zuccaops.GradlePublisherPlugin", properties.getProperty("implementation-class"))
         }
 
-        assertTrue(
-            candidateRepository
-                .resolve(
-                    "tech/yanand/maven-central-publish/" +
-                        "tech.yanand.maven-central-publish.gradle.plugin/1.2.0/" +
-                        "tech.yanand.maven-central-publish.gradle.plugin-1.2.0.pom",
-                ).exists(),
-        )
-        assertTrue(
-            candidateRepository
-                .resolve(
-                    "tech/yanand/gradle/maven-central-publish/1.2.0/" +
-                        "maven-central-publish-1.2.0.jar",
-                ).exists(),
+        assertFalse(
+            candidateRepository.resolve("tech/yanand").exists(),
+            "The isolated candidate repository must not stage Yanand artifacts",
         )
     }
 

--- a/src/main/kotlin/configuration/RepositoryConfig.kt
+++ b/src/main/kotlin/configuration/RepositoryConfig.kt
@@ -34,7 +34,7 @@ package dev.zuccaops.configuration
  *
  * @property target The URL or keyword for the repository. Examples:
  * - `"local"` to publish to local Maven
- * - `"mavenCentral"` to use flying-gradle-plugin
+ * - `"mavenCentral"` to use the Central Portal Publisher API
  * - `"nexus"` for OSSRH/Sonatype (requires `customGradleCommand`)
  * - or any full repository URL
  *

--- a/src/main/kotlin/repositories/RepositoryPublisherFactory.kt
+++ b/src/main/kotlin/repositories/RepositoryPublisherFactory.kt
@@ -19,10 +19,12 @@ import dev.zuccaops.configuration.RepositoryConfig
 import dev.zuccaops.helpers.VersionResolver
 import dev.zuccaops.helpers.publisherConfiguration
 import dev.zuccaops.repositories.central.MavenCentralRepositoryPublisher
+import dev.zuccaops.repositories.central.MavenCentralRepositoryPublisher.Companion.REPOSITORY_BASE_URL_PROPERTY
 import dev.zuccaops.repositories.central.NexusRepositoryPublisher
 import dev.zuccaops.repositories.local.LocalRepositoryPublisher
 import dev.zuccaops.repositories.remote.RemoteRepositoryPublisher
 import org.gradle.api.Project
+import org.gradle.api.artifacts.ArtifactRepositoryContainer.MAVEN_CENTRAL_URL
 
 /**
  * Factory responsible for selecting the correct [RepositoryPublisher] implementation
@@ -33,7 +35,7 @@ import org.gradle.api.Project
  *
  * Based on the selected configuration, it delegates to one of:
  * - [LocalRepositoryPublisher] (local testing/dev)
- * - [MavenCentralRepositoryPublisher] (via flying-gradle-plugin)
+ * - [MavenCentralRepositoryPublisher] (Central Portal bundle upload)
  * - [NexusRepositoryPublisher] (custom Gradle task for central)
  * - [RemoteRepositoryPublisher] (for Artifactory, Nexus, etc.)
  *
@@ -55,7 +57,13 @@ object RepositoryPublisherFactory {
             }
 
             RepositoryConstants.MAVEN_CENTRAL_COMMAND -> {
-                MavenCentralRepositoryPublisher(project, versionResolver, repositoryAuthenticator)
+                MavenCentralRepositoryPublisher(
+                    project,
+                    versionResolver,
+                    repositoryAuthenticator,
+                    project.findProperty(REPOSITORY_BASE_URL_PROPERTY)?.toString()
+                        ?: MAVEN_CENTRAL_URL.toString(),
+                )
             }
 
             RepositoryConstants.SONATYPE_COMMAND -> {

--- a/src/main/kotlin/repositories/central/CentralPortalClient.kt
+++ b/src/main/kotlin/repositories/central/CentralPortalClient.kt
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2025 GuidoZuccarelli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.zuccaops.repositories.central
+
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Path
+import java.time.Duration
+import java.util.UUID
+
+internal class CentralPortalClient(
+    private val baseUri: URI,
+    private val authToken: String,
+    private val httpClient: HttpClient = HttpClient.newHttpClient(),
+    private val sleep: (Duration) -> Unit = { duration -> Thread.sleep(duration.toMillis()) },
+    private val nanoTime: () -> Long = System::nanoTime,
+) {
+    fun uploadAndWait(
+        bundle: Path,
+        publishingType: String,
+        timeout: Duration,
+        pollInterval: Duration,
+    ): DeploymentStatus {
+        val deploymentId = upload(bundle, publishingType)
+        return waitForDeployment(deploymentId, timeout, pollInterval)
+    }
+
+    internal fun upload(
+        bundle: Path,
+        publishingType: String,
+    ): String {
+        val boundary = UUID.randomUUID().toString().replace("-", "")
+        val request =
+            HttpRequest
+                .newBuilder(endpoint("api/v1/publisher/upload?publishingType=${publishingType.urlEncode()}"))
+                .header("Authorization", "Bearer $authToken")
+                .header("Content-Type", "multipart/form-data; boundary=$boundary")
+                .POST(multipartBody(boundary, bundle))
+                .build()
+        val response = send(request)
+
+        if (response.statusCode() != UPLOAD_SUCCESS_STATUS) {
+            throw CentralPortalException(
+                "Upload failed, status code: [${response.statusCode()}], response body: ${response.body()}",
+            )
+        }
+
+        return response.body().trim().ifEmpty {
+            throw CentralPortalException("Upload succeeded, but the Central Portal returned an empty deployment ID.")
+        }
+    }
+
+    internal fun waitForDeployment(
+        deploymentId: String,
+        timeout: Duration,
+        pollInterval: Duration,
+    ): DeploymentStatus {
+        val deadline = nanoTime() + timeout.toNanos()
+
+        while (true) {
+            pause(pollInterval)
+            val status = parseDeploymentStatus(deploymentStatus(deploymentId))
+
+            when (status.state) {
+                DeploymentState.VALIDATED,
+                DeploymentState.PUBLISHING,
+                DeploymentState.PUBLISHED,
+                -> {
+                    return status
+                }
+
+                DeploymentState.FAILED -> {
+                    throw CentralPortalException(
+                        "Deployment status is failed: [${status.state}], response body: ${status.responseBody}, " +
+                            "please go to [$DEPLOYMENTS_URL] check your deployment.",
+                    )
+                }
+
+                DeploymentState.PENDING,
+                DeploymentState.VALIDATING,
+                -> {
+                    Unit
+                }
+            }
+
+            if (nanoTime() >= deadline) {
+                throw CentralPortalException(
+                    "Deployment hasn't finished, status is: [${status.state}], " +
+                        "please go to [$DEPLOYMENTS_URL] check your deployment.",
+                )
+            }
+        }
+    }
+
+    private fun pause(duration: Duration) {
+        try {
+            sleep(duration)
+        } catch (exception: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw CentralPortalException("Central Portal status polling was interrupted.", exception)
+        }
+    }
+
+    private fun deploymentStatus(deploymentId: String): String {
+        val request =
+            HttpRequest
+                .newBuilder(endpoint("api/v1/publisher/status?id=${deploymentId.urlEncode()}"))
+                .header("Authorization", "Bearer $authToken")
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .build()
+        val response = send(request)
+
+        if (response.statusCode() != STATUS_SUCCESS_STATUS) {
+            throw CentralPortalException(
+                "Check status failed, status code: [${response.statusCode()}], response body: ${response.body()}",
+            )
+        }
+
+        return response.body()
+    }
+
+    private fun parseDeploymentStatus(responseBody: String): DeploymentStatus {
+        val stateValue =
+            DEPLOYMENT_STATE_PATTERN
+                .find(responseBody)
+                ?.groupValues
+                ?.get(1)
+                ?: throw CentralPortalException(
+                    "The API did not return the 'deploymentState' field. Response body: $responseBody",
+                )
+        val state =
+            runCatching { DeploymentState.valueOf(stateValue) }.getOrElse {
+                throw CentralPortalException(
+                    "The API returned an unsupported deployment state: [$stateValue]. Response body: $responseBody",
+                )
+            }
+
+        return DeploymentStatus(state, responseBody)
+    }
+
+    private fun send(request: HttpRequest): HttpResponse<String> =
+        try {
+            httpClient.send(request, HttpResponse.BodyHandlers.ofString(UTF_8))
+        } catch (exception: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw CentralPortalException("Central Portal request was interrupted.", exception)
+        } catch (exception: Exception) {
+            throw CentralPortalException("Central Portal request failed: ${exception.message}", exception)
+        }
+
+    private fun endpoint(relativePath: String): URI {
+        val normalizedBase = baseUri.toString().trimEnd('/')
+        return URI.create("$normalizedBase/$relativePath")
+    }
+
+    private fun multipartBody(
+        boundary: String,
+        bundle: Path,
+    ): HttpRequest.BodyPublisher {
+        val prefix =
+            buildString {
+                append("--")
+                append(boundary)
+                append(CRLF)
+                append("Content-Disposition: form-data; name=\"bundle\"; filename=\"")
+                append(bundle.fileName)
+                append("\"")
+                append(CRLF)
+                append("Content-Type: application/octet-stream")
+                append(CRLF)
+                append(CRLF)
+            }
+        val suffix = "$CRLF--$boundary--$CRLF"
+
+        return HttpRequest.BodyPublishers.concat(
+            HttpRequest.BodyPublishers.ofString(prefix, UTF_8),
+            HttpRequest.BodyPublishers.ofFile(bundle),
+            HttpRequest.BodyPublishers.ofString(suffix, UTF_8),
+        )
+    }
+
+    private fun String.urlEncode(): String = URLEncoder.encode(this, UTF_8)
+
+    internal data class DeploymentStatus(
+        val state: DeploymentState,
+        val responseBody: String,
+    )
+
+    internal enum class DeploymentState {
+        PENDING,
+        VALIDATING,
+        VALIDATED,
+        PUBLISHING,
+        PUBLISHED,
+        FAILED,
+    }
+
+    private companion object {
+        const val CRLF = "\r\n"
+        const val UPLOAD_SUCCESS_STATUS = 201
+        const val STATUS_SUCCESS_STATUS = 200
+        const val DEPLOYMENTS_URL = "https://central.sonatype.com/publishing/deployments"
+        val DEPLOYMENT_STATE_PATTERN = Regex(""""deploymentState"\s*:\s*"([^"]+)"""")
+    }
+}
+
+internal class CentralPortalException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/src/main/kotlin/repositories/central/MavenCentralRepositoryPublisher.kt
+++ b/src/main/kotlin/repositories/central/MavenCentralRepositoryPublisher.kt
@@ -17,18 +17,18 @@ package dev.zuccaops.repositories.central
 
 import dev.zuccaops.helpers.VersionResolver
 import dev.zuccaops.repositories.RepositoryAuthenticator
-import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.artifacts.ArtifactRepositoryContainer.MAVEN_CENTRAL_URL
 import org.gradle.api.artifacts.dsl.RepositoryHandler
-import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.provider.Property
+import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
+import org.gradle.api.tasks.bundling.Zip
 import java.util.Base64
 
 /**
- * Publisher that targets the new Maven Central (Central Portal) using the [flying-gradle-plugin](https://github.com/yananhub/flying-gradle-plugin).
+ * Publisher that targets the Maven Central Portal.
  *
- * This class dynamically applies the plugin and configures it using reflection to avoid compile-time dependency.
- * It uses `USER_MANAGED` publishing mode, so manual review and publishing is expected in the portal.
+ * It stages Maven-layout artifacts locally, creates a deployment bundle, and uploads it using
+ * `USER_MANAGED` publishing mode so manual review and publishing is expected in the portal.
  *
  * For release branches, the plugin checks if the artifact already exists in Maven Central
  * and skips publishing if it has already been released.
@@ -45,26 +45,24 @@ class MavenCentralRepositoryPublisher(
     private val project: Project,
     private val versionResolver: VersionResolver,
     private val repositoryAuthenticator: RepositoryAuthenticator,
-) : SonatypeRepositoryPublisher(project, versionResolver) {
+    repositoryBaseUrl: String = MAVEN_CENTRAL_URL.toString(),
+) : SonatypeRepositoryPublisher(project, versionResolver, repositoryBaseUrl) {
     companion object {
-        // Plugin routing details
         const val ROUTING_COMMAND = "publishToMavenCentralPortal"
-        const val ROUTING_PLUGIN_ID = "tech.yanand.maven-central-publish"
-
-        // Extension and reflection method names
-        const val MAVEN_CENTRAL_EXTENSION_NAME = "mavenCentral"
-        const val METHOD_GET_REPO_DIR = "getRepoDir"
-        const val METHOD_GET_AUTH_TOKEN = "getAuthToken"
-        const val METHOD_GET_PUBLISHING_TYPE = "getPublishingType"
-
-        // Other constants
+        const val ZIP_TASK_NAME = "zipBundleForUpload"
         const val DEFAULT_REPO_DIR_PATH = "repos/bundles"
+        const val DEFAULT_PORTAL_BASE_URL = "https://central.sonatype.com"
+        const val DEFAULT_MAX_WAIT_SECONDS = 60L
+        const val DEFAULT_POLL_INTERVAL_MILLIS = 10_000L
         const val PUBLISHING_TYPE_USER_MANAGED = "USER_MANAGED"
+        const val PORTAL_BASE_URL_PROPERTY = "mavenCentralPortalBaseUrl"
+        const val MAX_WAIT_SECONDS_PROPERTY = "mavenCentralPortalMaxWaitSeconds"
+        const val POLL_INTERVAL_MILLIS_PROPERTY = "mavenCentralPortalPollIntervalMillis"
+        const val REPOSITORY_BASE_URL_PROPERTY = "mavenCentralRepositoryBaseUrl"
     }
 
     /**
-     * Applies the `flying-gradle-plugin` and configures it.
-     * Also finalizes the `publish` task with `publishToMavenCentralPortal`.
+     * Configures bundle creation and finalizes `publish` with the Central Portal upload.
      */
     override fun configurePublishingRepository() {
         super.configurePublishingRepository()
@@ -91,14 +89,10 @@ class MavenCentralRepositoryPublisher(
             return
         }
 
-        project.logger.lifecycle("Applying $ROUTING_PLUGIN_ID plugin")
-        project.pluginManager.apply(ROUTING_PLUGIN_ID)
-
-        val encodedCredentials = encodeBasicAuth(username, password)
-        configureMavenCentralExtension(encodedCredentials)
+        registerPortalTasks(encodeBasicAuth(username, password))
 
         project.tasks.named("publish").configure {
-            project.logger.lifecycle("⚙️ Routing 'publish' to '$ROUTING_COMMAND' after finish")
+            project.logger.lifecycle("Routing 'publish' to '$ROUTING_COMMAND' after finish")
             finalizedBy(ROUTING_COMMAND)
         }
     }
@@ -118,51 +112,62 @@ class MavenCentralRepositoryPublisher(
     override fun shouldSign(): Boolean = true
 
     /**
-     * Register a local bundle directory that flying-gradle-plugin will zip and upload.
+     * Register the local Maven repository that will be zipped and uploaded.
      */
     override fun registerRepository(repositoryHandler: RepositoryHandler) {
         repositoryHandler.maven {
             name = "Local"
             url =
                 project.layout.buildDirectory
-                    .dir("repos/bundles")
+                    .dir(DEFAULT_REPO_DIR_PATH)
                     .get()
                     .asFile
                     .toURI()
         }
     }
 
-    /**
-     * Configures `flying-gradle-plugin` extension using reflection
-     */
-    @Suppress("UNCHECKED_CAST")
-    private fun configureMavenCentralExtension(encodedCredentials: String) {
-        project.logger.info("Configuring mavenCentral extension")
-        project.extensions.configure(
-            MAVEN_CENTRAL_EXTENSION_NAME,
-            Action<Any> {
-                val clazz = this.javaClass
+    private fun registerPortalTasks(encodedCredentials: String) {
+        val repoDirectory = project.layout.buildDirectory.dir(DEFAULT_REPO_DIR_PATH)
+        val zipTask =
+            project.tasks.register(ZIP_TASK_NAME, Zip::class.java) {
+                group = "central publish"
+                description = "Creates the Maven Central Portal deployment bundle."
+                from(repoDirectory)
+                archiveFileName.set("bundles.zip")
+                destinationDirectory.set(project.layout.buildDirectory.dir("repos"))
+                isPreserveFileTimestamps = false
+                isReproducibleFileOrder = true
+                dependsOn(
+                    project.tasks
+                        .withType(PublishToMavenRepository::class.java)
+                        .matching { it.repository.name == "Local" },
+                )
+            }
 
-                project.logger.debug("Setting repoDir to $DEFAULT_REPO_DIR_PATH")
-                val repoDir = project.layout.buildDirectory.dir(DEFAULT_REPO_DIR_PATH)
-
-                clazz
-                    .getMethod(METHOD_GET_REPO_DIR)
-                    .invoke(this)
-                    .let { (it as DirectoryProperty).set(repoDir) }
-
-                project.logger.debug("Setting authToken with encoded credentials")
-                clazz
-                    .getMethod(METHOD_GET_AUTH_TOKEN)
-                    .invoke(this)
-                    .let { (it as Property<String>).set(encodedCredentials) }
-
-                project.logger.debug("Setting publishingType to $PUBLISHING_TYPE_USER_MANAGED")
-                clazz
-                    .getMethod(METHOD_GET_PUBLISHING_TYPE)
-                    .invoke(this)
-                    .let { (it as Property<String>).set(PUBLISHING_TYPE_USER_MANAGED) }
-            },
-        )
+        project.tasks.register(ROUTING_COMMAND, PublishToCentralPortalTask::class.java) {
+            group = "central publish"
+            description = "Uploads a deployment bundle to the Maven Central Portal."
+            dependsOn(zipTask)
+            bundleFile.set(zipTask.flatMap { it.archiveFile })
+            authToken.set(encodedCredentials)
+            baseUrl.set(
+                project.providers
+                    .gradleProperty(PORTAL_BASE_URL_PROPERTY)
+                    .orElse(DEFAULT_PORTAL_BASE_URL),
+            )
+            publishingType.set(PUBLISHING_TYPE_USER_MANAGED)
+            maxWaitSeconds.set(
+                project.providers
+                    .gradleProperty(MAX_WAIT_SECONDS_PROPERTY)
+                    .map(String::toLong)
+                    .orElse(DEFAULT_MAX_WAIT_SECONDS),
+            )
+            pollIntervalMillis.set(
+                project.providers
+                    .gradleProperty(POLL_INTERVAL_MILLIS_PROPERTY)
+                    .map(String::toLong)
+                    .orElse(DEFAULT_POLL_INTERVAL_MILLIS),
+            )
+        }
     }
 }

--- a/src/main/kotlin/repositories/central/PublishToCentralPortalTask.kt
+++ b/src/main/kotlin/repositories/central/PublishToCentralPortalTask.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 GuidoZuccarelli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.zuccaops.repositories.central
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import java.net.URI
+import java.time.Duration
+
+@DisableCachingByDefault(because = "Uploads a deployment bundle to an external service")
+abstract class PublishToCentralPortalTask : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val bundleFile: RegularFileProperty
+
+    @get:Input
+    abstract val authToken: Property<String>
+
+    @get:Input
+    abstract val baseUrl: Property<String>
+
+    @get:Input
+    abstract val publishingType: Property<String>
+
+    @get:Input
+    abstract val maxWaitSeconds: Property<Long>
+
+    @get:Input
+    abstract val pollIntervalMillis: Property<Long>
+
+    @TaskAction
+    fun upload() {
+        val status =
+            try {
+                CentralPortalClient(
+                    baseUri = URI.create(baseUrl.get()),
+                    authToken = authToken.get(),
+                ).uploadAndWait(
+                    bundle = bundleFile.get().asFile.toPath(),
+                    publishingType = publishingType.get(),
+                    timeout = Duration.ofSeconds(maxWaitSeconds.get()),
+                    pollInterval = Duration.ofMillis(pollIntervalMillis.get()),
+                )
+            } catch (exception: CentralPortalException) {
+                throw GradleException(exception.message ?: "Central Portal upload failed.", exception)
+            }
+
+        logger.lifecycle("Upload file success! current status: {}.", status.state)
+    }
+}

--- a/src/main/kotlin/repositories/central/SonatypeRepositoryPublisher.kt
+++ b/src/main/kotlin/repositories/central/SonatypeRepositoryPublisher.kt
@@ -28,6 +28,7 @@ import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesti
 abstract class SonatypeRepositoryPublisher(
     private val project: Project,
     private val versionResolver: VersionResolver,
+    private val repositoryBaseUrl: String = ArtifactRepositoryContainer.MAVEN_CENTRAL_URL.toString(),
 ) : BaseRepositoryPublisher(project, versionResolver) {
     private var isPublishable: Boolean? = null
 
@@ -42,7 +43,7 @@ abstract class SonatypeRepositoryPublisher(
         val group = project.group.toString().replace(".", "/")
         val name = project.name.replace(".", "/")
 
-        return "${ArtifactRepositoryContainer.MAVEN_CENTRAL_URL}$group/$name/${versionResolver.getVersion()}"
+        return "${repositoryBaseUrl.trimEnd('/')}/$group/$name/${versionResolver.getVersion()}"
     }
 
     override fun isPublishable(): Boolean {

--- a/src/test/kotlin/repositories/central/CentralPortalClientTest.kt
+++ b/src/test/kotlin/repositories/central/CentralPortalClientTest.kt
@@ -1,0 +1,300 @@
+package repositories.central
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import dev.zuccaops.repositories.central.CentralPortalClient
+import dev.zuccaops.repositories.central.CentralPortalClient.DeploymentState
+import dev.zuccaops.repositories.central.CentralPortalException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.net.InetSocketAddress
+import java.net.URI
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Path
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+
+class CentralPortalClientTest {
+    lateinit var temporaryDirectory: Path
+
+    @BeforeEach
+    fun createTemporaryDirectory() {
+        temporaryDirectory =
+            Path
+                .of(System.getProperty("user.dir"), "build", "unit-test-projects", UUID.randomUUID().toString())
+                .createDirectories()
+    }
+
+    @Test
+    fun `uploads a multipart bundle with bearer authentication and user managed publishing`() {
+        FakeCentralPortalServer().use { server ->
+            val bundle = temporaryDirectory.resolve("central-bundle.zip")
+            bundle.writeText("bundle-content")
+
+            val deploymentId = client(server).upload(bundle, "USER_MANAGED")
+
+            assertEquals("deployment-123", deploymentId)
+            val request = server.requests.single()
+            assertEquals("POST", request.method)
+            assertEquals("/api/v1/publisher/upload", request.path)
+            assertEquals("publishingType=USER_MANAGED", request.query)
+            assertEquals("Bearer encoded-token", request.authorization)
+            assertTrue(request.contentType.startsWith("multipart/form-data; boundary="))
+
+            val boundary = request.contentType.substringAfter("boundary=")
+            val body = request.body.toString(UTF_8)
+            assertTrue(body.startsWith("--$boundary\r\n"))
+            assertTrue(body.contains("Content-Disposition: form-data; name=\"bundle\"; filename=\"central-bundle.zip\""))
+            assertTrue(body.contains("Content-Type: application/octet-stream\r\n\r\nbundle-content"))
+            assertTrue(body.endsWith("\r\n--$boundary--\r\n"))
+        }
+    }
+
+    @Test
+    fun `reports upload response failures`() {
+        FakeCentralPortalServer(uploadResponse = Response(400, "invalid bundle")).use { server ->
+            val bundle = temporaryDirectory.resolve("central-bundle.zip")
+            bundle.writeText("bundle-content")
+
+            val exception =
+                assertThrows<CentralPortalException> {
+                    client(server).upload(bundle, "USER_MANAGED")
+                }
+
+            assertEquals("Upload failed, status code: [400], response body: invalid bundle", exception.message)
+        }
+    }
+
+    @Test
+    fun `rejects an empty deployment id`() {
+        FakeCentralPortalServer(uploadResponse = Response(201, "  ")).use { server ->
+            val bundle = temporaryDirectory.resolve("central-bundle.zip")
+            bundle.writeText("bundle-content")
+
+            val exception =
+                assertThrows<CentralPortalException> {
+                    client(server).upload(bundle, "USER_MANAGED")
+                }
+
+            assertTrue(exception.message!!.contains("empty deployment ID"))
+        }
+    }
+
+    @Test
+    fun `polls pending and validating deployments until validated`() {
+        FakeCentralPortalServer(
+            statusResponses =
+                listOf(
+                    statusResponse("PENDING"),
+                    statusResponse("VALIDATING"),
+                    statusResponse("VALIDATED"),
+                ),
+        ).use { server ->
+            val status =
+                client(server).waitForDeployment(
+                    deploymentId = "deployment-123",
+                    timeout = Duration.ofSeconds(60),
+                    pollInterval = Duration.ZERO,
+                )
+
+            assertEquals(DeploymentState.VALIDATED, status.state)
+            assertEquals(3, server.requests.size)
+            assertTrue(server.requests.all { it.method == "POST" })
+            assertTrue(server.requests.all { it.query == "id=deployment-123" })
+        }
+    }
+
+    @Test
+    fun `accepts publishing and published as terminal states`() {
+        listOf(DeploymentState.PUBLISHING, DeploymentState.PUBLISHED).forEach { terminalState ->
+            FakeCentralPortalServer(
+                statusResponses = listOf(statusResponse(terminalState.name)),
+            ).use { server ->
+                val status =
+                    client(server).waitForDeployment(
+                        deploymentId = "deployment-123",
+                        timeout = Duration.ofSeconds(60),
+                        pollInterval = Duration.ZERO,
+                    )
+
+                assertEquals(terminalState, status.state)
+                assertEquals(1, server.requests.size)
+            }
+        }
+    }
+
+    @Test
+    fun `reports failed deployments with portal response details`() {
+        val responseBody = """{"deploymentState":"FAILED","errors":{"pom":["missing name"]}}"""
+        FakeCentralPortalServer(
+            statusResponses = listOf(Response(200, responseBody)),
+        ).use { server ->
+            val exception =
+                assertThrows<CentralPortalException> {
+                    client(server).waitForDeployment(
+                        deploymentId = "deployment-123",
+                        timeout = Duration.ofSeconds(60),
+                        pollInterval = Duration.ZERO,
+                    )
+                }
+
+            val message = exception.message.orEmpty()
+            assertTrue(message.contains("Deployment status is failed: [FAILED]"))
+            assertTrue(message.contains("missing name"))
+        }
+    }
+
+    @Test
+    fun `times out with the last deployment state`() {
+        var now = 0L
+        FakeCentralPortalServer(
+            statusResponses = listOf(statusResponse("PENDING")),
+        ).use { server ->
+            val client =
+                CentralPortalClient(
+                    baseUri = server.uri,
+                    authToken = "encoded-token",
+                    sleep = { duration -> now += duration.toNanos() },
+                    nanoTime = { now },
+                )
+
+            val exception =
+                assertThrows<CentralPortalException> {
+                    client.waitForDeployment(
+                        deploymentId = "deployment-123",
+                        timeout = Duration.ofSeconds(2),
+                        pollInterval = Duration.ofSeconds(1),
+                    )
+                }
+
+            assertTrue(exception.message!!.contains("Deployment hasn't finished, status is: [PENDING]"))
+            assertEquals(2, server.requests.size)
+        }
+    }
+
+    @Test
+    fun `reports status response failures`() {
+        FakeCentralPortalServer(
+            statusResponses = listOf(Response(503, "temporarily unavailable")),
+        ).use { server ->
+            val exception =
+                assertThrows<CentralPortalException> {
+                    client(server).waitForDeployment(
+                        deploymentId = "deployment-123",
+                        timeout = Duration.ofSeconds(60),
+                        pollInterval = Duration.ZERO,
+                    )
+                }
+
+            assertEquals(
+                "Check status failed, status code: [503], response body: temporarily unavailable",
+                exception.message,
+            )
+        }
+    }
+
+    @Test
+    fun `reports a missing deployment state`() {
+        FakeCentralPortalServer(
+            statusResponses = listOf(Response(200, """{"deploymentId":"deployment-123"}""")),
+        ).use { server ->
+            val exception =
+                assertThrows<CentralPortalException> {
+                    client(server).waitForDeployment(
+                        deploymentId = "deployment-123",
+                        timeout = Duration.ofSeconds(60),
+                        pollInterval = Duration.ZERO,
+                    )
+                }
+
+            assertTrue(exception.message!!.contains("did not return the 'deploymentState' field"))
+        }
+    }
+
+    private fun client(server: FakeCentralPortalServer): CentralPortalClient =
+        CentralPortalClient(
+            baseUri = server.uri,
+            authToken = "encoded-token",
+            sleep = {},
+        )
+
+    private companion object {
+        fun statusResponse(state: String) = Response(200, """{"deploymentState":"$state"}""")
+    }
+}
+
+private data class Response(
+    val status: Int,
+    val body: String,
+)
+
+private class FakeCentralPortalServer(
+    private val uploadResponse: Response = Response(201, "deployment-123"),
+    statusResponses: List<Response> = listOf(Response(200, """{"deploymentState":"VALIDATED"}""")),
+) : AutoCloseable {
+    data class Request(
+        val method: String,
+        val path: String,
+        val query: String?,
+        val authorization: String?,
+        val contentType: String,
+        val body: ByteArray,
+    )
+
+    private val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    private val recordedRequests = CopyOnWriteArrayList<Request>()
+    private val responses = statusResponses.toList()
+    private val statusIndex = AtomicInteger()
+
+    val uri: URI
+        get() = URI("http://127.0.0.1:${server.address.port}")
+
+    val requests: List<Request>
+        get() = recordedRequests.toList()
+
+    init {
+        server.createContext("/api/v1/publisher/upload") { exchange ->
+            record(exchange)
+            respond(exchange, uploadResponse)
+        }
+        server.createContext("/api/v1/publisher/status") { exchange ->
+            record(exchange)
+            val index = statusIndex.getAndIncrement().coerceAtMost(responses.lastIndex)
+            respond(exchange, responses[index])
+        }
+        server.start()
+    }
+
+    override fun close() {
+        server.stop(0)
+    }
+
+    private fun record(exchange: HttpExchange) {
+        recordedRequests +=
+            Request(
+                method = exchange.requestMethod,
+                path = exchange.requestURI.path,
+                query = exchange.requestURI.rawQuery,
+                authorization = exchange.requestHeaders.getFirst("Authorization"),
+                contentType = exchange.requestHeaders.getFirst("Content-Type").orEmpty(),
+                body = exchange.requestBody.use { it.readBytes() },
+            )
+    }
+
+    private fun respond(
+        exchange: HttpExchange,
+        response: Response,
+    ) {
+        val body = response.body.toByteArray(UTF_8)
+        exchange.sendResponseHeaders(response.status, body.size.toLong())
+        exchange.responseBody.use { it.write(body) }
+        exchange.close()
+    }
+}


### PR DESCRIPTION
Remove the Yanand runtime dependency and implement Maven Central Portal bundle creation, authenticated upload, and status polling internally using Java 17 and Gradle task types. Add unit, functional, and offline packaged-plugin integration coverage while preserving existing publishing behavior and Maven Local support. (#54)